### PR TITLE
(breaking change) bump crystal support to 1.6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,19 +1,18 @@
 name: CI
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+    types: ['opened', 'reopened', 'synchronize', 'ready_for_review']
+
 
 jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: crystallang/crystal:0.34.0-alpine
+      image: crystallang/crystal:1.6.0-alpine
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: apk add --no-cache libarchive-dev
     - name: Test

--- a/src/archive.cr
+++ b/src/archive.cr
@@ -27,7 +27,7 @@ module Archive
   class Entry
     getter filename : String
     getter size : LibC::SizeT
-    getter info : Crystal::System::FileInfo
+    getter info : File::Info
 
     property file : File?
 
@@ -75,7 +75,7 @@ module Archive
         name = String.new char_ptr
 
         stat = LibArchive.archive_entry_stat(e).value
-        info = Crystal::System::FileInfo.new stat
+        info = File::Info.new stat
         entry = Entry.new name, size, info
 
         yield entry

--- a/src/archive.cr
+++ b/src/archive.cr
@@ -27,7 +27,7 @@ module Archive
   class Entry
     getter filename : String
     getter size : LibC::SizeT
-    getter info : File::Info
+    getter info : ::File::Info
 
     property file : File?
 
@@ -75,7 +75,7 @@ module Archive
         name = String.new char_ptr
 
         stat = LibArchive.archive_entry_stat(e).value
-        info = File::Info.new stat
+        info = ::File::Info.new stat
         entry = Entry.new name, size, info
 
         yield entry

--- a/src/archive.cr
+++ b/src/archive.cr
@@ -90,7 +90,7 @@ module Archive
 
         buffer = Bytes.new e.size
         read_size = LibArchive.archive_read_data @a, buffer, e.size
-        raise? if read_size < 0
+        raise? if read_size <= 0
 
         yield buffer
       end

--- a/src/archive.cr
+++ b/src/archive.cr
@@ -90,7 +90,7 @@ module Archive
 
         buffer = Bytes.new e.size
         read_size = LibArchive.archive_read_data @a, buffer, e.size
-        raise? if read_size <= 0
+        raise? if read_size < 0
 
         yield buffer
       end

--- a/src/archive.cr
+++ b/src/archive.cr
@@ -154,12 +154,15 @@ module Archive
     #   This is useful when checking the integrity of the archive.
     def check
       reader do |r|
+        all_zero_files = false
         r.entries do |e|
           next unless e.info.file?
           e.file = self
-          e.read
-          break
+          data = e.read
+          break if data.size > 0
+          all_zero_files = true
         end
+        raise Error.new "No file entries found in the archive" if all_zero_files
       end
     end
   end

--- a/src/libarchive.cr
+++ b/src/libarchive.cr
@@ -7,6 +7,7 @@ lib LibArchive
   type Archive = Void*
   type ArchiveEntry = Void*
 
+  # https://github.com/libarchive/libarchive/blob/819a50a0436531276e388fc97eb0b1b61d2134a3/libarchive/archive.h#L190
   enum Status
     EOF    =   1
     OK     =   0


### PR DESCRIPTION
On upgrading to next crystal version, the following error was observed:

```
Error: instantiating 'Crystal::System::FileInfo.new(LibC::Stat)'
```

This is due to change in behaviour introduced in [Crystal 1.6.0](https://crystal-lang.org/api/1.6.0/File/Info.html), where `File::Info` became a `struct` and in [earlier versions](https://crystal-lang.org/api/1.5.0/File/Info.html). it was `abstract struct`. Additionally, in the [latest version](https://crystal-lang.org/api/1.14.0/File/Info.html) `Crystal::System::FileInfo` became a module
Issue: https://github.com/crystal-lang/crystal/pull/12385

The new version of libarchive (3.7.4) does not throw error when the archive has bad files. The previous version used in this build was 3.4.x). Modified the check to throw error when none of the files in the archive have valid files.
