### PR TITLE
bump crystal support to 1.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /shard.lock
 
 *.rar
+**/.DS_STORE

--- a/shard.yml
+++ b/shard.yml
@@ -1,9 +1,10 @@
 name: archive
-version: 0.5.0
+version: 0.6.0
 
 authors:
   - Alex Ling <hkalexling@gmail.com>
+  - Sandeep Rao
 
-crystal: 1.0.0
+crystal: 1.6.0
 
 license: MIT


### PR DESCRIPTION
Major work for supporting this crystal version was done in https://github.com/vrsandeep/archive.cr/pull/1